### PR TITLE
refactor: Moved AuditLogs to DataTable

### DIFF
--- a/src/Controller/Admin/System/AuditLog/AuditLogController.php
+++ b/src/Controller/Admin/System/AuditLog/AuditLogController.php
@@ -21,13 +21,21 @@ class AuditLogController extends AbstractController
     #[Route('/admin/system/audit_log', name: 'app_admin_system_auditlog')]
     public function index(
         #[MapQueryParameter]
-        int $page = 1
+        int $page = 1,
+        #[MapQueryParameter]
+        string $search = '',
+        #[MapQueryParameter]
+        string $sortBy = 'id',
+        #[MapQueryParameter]
+        string $orderBy = 'asc',
     ): Response {
-        /** @var Paginator $auditLogs */
-        $auditLogs = $this->query->execute($page);
+        /** @var Paginator $paginator */
+        $paginator = $this->query->execute($page, 10);
 
         return $this->render('admin/system/audit_log/list.html.twig', [
-            'audit_logs' => $auditLogs,
+            'paginator' => $paginator,
+            'sortBy' => $sortBy,
+            'orderBy' => $orderBy,
         ]);
     }
 }

--- a/src/Twig/Components/AuditLogWidget.php
+++ b/src/Twig/Components/AuditLogWidget.php
@@ -16,6 +16,6 @@ final readonly class AuditLogWidget
 
     public function getLatestLogs(): Paginator
     {
-        return $this->query->execute(1, 5);
+        return $this->query->execute(1, 10);
     }
 }

--- a/templates/admin/system/audit_log/list.html.twig
+++ b/templates/admin/system/audit_log/list.html.twig
@@ -1,5 +1,7 @@
 {% extends 'admin/_base.html.twig' %}
 
+{% import 'macros/pagination.html.twig' as pagination %}
+
 {% block title %}{{ "title.audit_log"|trans }} - {{ parent() }}{% endblock %}
 
 {% block admin_breadcrumb %}
@@ -21,86 +23,91 @@
 {% endblock %}
 
 {% block body %}
-    <div class="row justify-content-center">
-        <div class="card">
-            <div class="card-body">
-                <div class="divide-y">
-                    {% for auditlog in audit_logs.getResults %}
-                        <div>
-                            <div class="row">
-                                <div class="col-auto">
-                                    <span class="avatar small"><a href="{{ path('app_admin_system_auditlog_detail', {id: auditlog.id}) }}">#{{ auditlog.id }}</a></span>
-                                </div>
-                                <div class="col">
-                                    <div class="text-truncate">
-                                        {% if auditlog.user is null %}
-                                            <strong>{{ auditlog.entityType }} ({{ auditlog.entityId }})</strong> was <strong>{{ auditlog.action }}</strong>.
-                                        {% else %}{{ auditlog.user }}
-                                            <strong>{{ auditlog.entityType }} ({{ auditlog.entityId }})</strong> was <strong>{{ auditlog.action }}</strong> by {{ auditlog.user }}.
-                                        {% endif %}
-                                    </div>
-                                    <div class="text-muted">{{ auditlog.createdAt|date('d.m.Y H:i') }}</div>
-                                </div>
-                            </div>
-                        </div>
+<turbo-frame id="user-list" data-turbo-action="advance" target="_top">
+    <div class="card">
+        <div class="card-body">
+            <div id="table-default" class="table-responsive">
+                <table class="table">
+                    <thead>
+                    <tr>
+                        <th class="col-1">
+                            {{ "label.id"|trans }}
+                        </th>
+                        <th class="col-2">
+                            {{ "label.user"|trans }}
+                        </th>
+                        <th class="col-2">
+                            {{ "label.action"|trans }}
+                        </th>
+                        <th class="col-2">
+                            {{ "label.entity"|trans }}
+                        </th>
+                        <th>
+                            {{ "label.created_at"|trans }}
+                        </th>
+                        <th class="col-2">
+                            {{ "label.actions"|trans }}
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for auditlog in paginator.results %}
+                        <tr>
+                            <td>
+                                <a href="{{ path('app_admin_system_auditlog_detail', {id: auditlog.id}) }}">#{{ auditlog.id }}</a>
+                            </td>
+                            <td>
+                                {{ auditlog.user ?? '<code>none</code>' }}
+                            </td>
+                            <td>
+                                {{ auditlog.action }}
+                            </td>
+                            <td>
+                                {{ auditlog.entityType }} ({{ auditlog.entityId }})
+                            </td>
+                            <td>
+                                {{ auditlog.createdAt|date('d.m.Y H:i') }}
+                            </td>
+                            <td>
+                                <a class="btn btn-sm btn-primary" href="{{ path('app_admin_system_auditlog_detail', {id: auditlog.id}) }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-eye-filled" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                        <path d="M12 4c4.29 0 7.863 2.429 10.665 7.154l.22 .379l.045 .1l.03 .083l.014 .055l.014 .082l.011 .1v.11l-.014 .111a.992 .992 0 0 1 -.026 .11l-.039 .108l-.036 .075l-.016 .03c-2.764 4.836 -6.3 7.38 -10.555 7.499l-.313 .004c-4.396 0 -8.037 -2.549 -10.868 -7.504a1 1 0 0 1 0 -.992c2.831 -4.955 6.472 -7.504 10.868 -7.504zm0 5a3 3 0 1 0 0 6a3 3 0 0 0 0 -6z" stroke-width="0" fill="currentColor" />
+                                    </svg>
+                                    &nbsp;{{ "label.show"|trans }}
+                                </a>
+                            </td>
+                        </tr>
                     {% else %}
-                        <div class="empty">
-                            <div class="empty-icon">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <circle cx="12" cy="12" r="9" />
-                                    <line x1="9" y1="10" x2="9.01" y2="10" />
-                                    <line x1="15" y1="10" x2="15.01" y2="10" />
-                                    <path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" />
-                                </svg>
-                            </div>
-                            <p class="empty-title">{{ "label.search_no_results"|trans }}</p>
-                            <p class="empty-subtitle text-secondary">
-                                {{ "help.search_no_results"|trans }}
-                            </p>
-                        </div>
+                        <tr>
+                            <td colspan="6">
+                                <div class="empty">
+                                    <div class="empty-icon">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <circle cx="12" cy="12" r="9" />
+                                            <line x1="9" y1="10" x2="9.01" y2="10" />
+                                            <line x1="15" y1="10" x2="15.01" y2="10" />
+                                            <path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" />
+                                        </svg>
+                                    </div>
+                                    <p class="empty-title">{{ "label.search_no_results"|trans }}</p>
+                                    <p class="empty-subtitle text-secondary">
+                                        {{ "help.search_no_results"|trans }}
+                                    </p>
+                                </div>
+                            </td>
+                        </tr>
                     {% endfor %}
-                </div>
-            </div>
-            <div class="card-footer d-flex align-items-center">
-                <p class="m-0 text-muted">Showing <span>{{ audit_logs.numResults }}</span> results, with <span>{{ audit_logs.pageSize }}</span> per page.</p>
-                {% if audit_logs.hasToPaginate %}
-                    <ul class="pagination m-0 ms-auto">
-                        {% if audit_logs.hasPreviousPage %}
-                            <li class="page-item">
-                                <a class="page-link" href="{{ path('app_admin_system_auditlog', {page: audit_logs.previousPage}) }}" tabindex="-1" aria-disabled="true">
-                                    <!-- Download SVG icon from http://tabler-icons.io/i/chevron-left -->
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 6l-6 6l6 6" /></svg>
-                                    {{ "label.previous"|trans }}
-                                </a>
-                            </li>
-                        {% else %}
-                            <li class="page-item disabled">
-                                <a class="page-link" href="#" tabindex="-1" aria-disabled="true">
-                                    <!-- Download SVG icon from http://tabler-icons.io/i/chevron-left -->
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 6l-6 6l6 6" /></svg>
-                                    {{ "label.previous"|trans }}
-                                </a>
-                            </li>
-                        {% endif %}
-                        {% if audit_logs.hasNextPage %}
-                            <li class="page-item">
-                                <a class="page-link" href="{{ path('app_admin_system_auditlog', {page: audit_logs.nextPage}) }}">
-                                    {{ "label.next"|trans }} <!-- Download SVG icon from http://tabler-icons.io/i/chevron-right -->
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg>
-                                </a>
-                            </li>
-                        {% else %}
-                            <li class="page-item disabled">
-                                <a class="page-link" href="{{ path('app_admin_system_auditlog', {page: audit_logs.nextPage}) }}">
-                                    {{ "label.next"|trans }} <!-- Download SVG icon from http://tabler-icons.io/i/chevron-right -->
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg>
-                                </a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                {% endif %}
+                    </tbody>
+                </table>
             </div>
         </div>
+        <div class="card-footer d-flex align-items-center">
+            {{ pagination.results(paginator.numResults, paginator.pageSize) }}
+
+            {{ pagination.navbar(paginator, 'app_admin_system_auditlog') }}
+        </div>
     </div>
+</turbo-frame>
 {% endblock %}

--- a/templates/admin/system/audit_log/list.html.twig
+++ b/templates/admin/system/audit_log/list.html.twig
@@ -57,13 +57,41 @@
                                 <a href="{{ path('app_admin_system_auditlog_detail', {id: auditlog.id}) }}">#{{ auditlog.id }}</a>
                             </td>
                             <td>
-                                {{ auditlog.user ?? '<code>none</code>' }}
+                                {% if auditlog.user %}
+                                    <a href="{{ path('app_admin_user_show', {id: auditlog.user.id}) }}">{{ auditlog.user }}</a>
+                                {% else %}
+                                    <code>none</code>
+                                {% endif %}
                             </td>
                             <td>
-                                {{ auditlog.action }}
+                                {% if auditlog.action == 'insert' %}
+                                    <span class="badge bg-green text-white">{{ 'label.action_insert'|trans }}</span>
+                                {% elseif auditlog.action == 'update' %}
+                                    <span class="badge bg-cyan text-white">{{ 'label.action_update'|trans }}</span>
+                                {% elseif auditlog.action == 'remove' %}
+                                    <span class="badge bg-red text-white">{{ 'label.action_remove'|trans }}</span>
+                                {% else %}
+                                    <span class="badge bg-secondary text-white">{{ auditlog.action }}</span>
+                                {% endif %}
                             </td>
                             <td>
-                                {{ auditlog.entityType }} ({{ auditlog.entityId }})
+                                {% if auditlog.action != 'remove' %}
+                                    {% if auditlog.entityType == 'User' %}
+                                        <a href="{{ path('app_admin_user_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'DispatchArea' %}
+                                        <a href="{{ path('app_admin_area_dispatch_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'State' %}
+                                        <a href="{{ path('app_admin_area_state_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'SupplyArea' %}
+                                        <a href="{{ path('app_admin_area_supply_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'Hospital' %}
+                                        <a href="{{ path('app_admin_hospital_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% else %}
+                                        {{ auditlog.entityType }} ({{ auditlog.entityId }})
+                                    {% endif %}
+                                {% else %}
+                                    <del class="text-muted">{{ auditlog.entityType }} ({{ auditlog.entityId }})</del>
+                                {% endif %}
                             </td>
                             <td>
                                 {{ auditlog.createdAt|date('d.m.Y H:i') }}

--- a/templates/components/AuditLogWidget.html.twig
+++ b/templates/components/AuditLogWidget.html.twig
@@ -6,17 +6,65 @@
                     <div>
                         <div class="row">
                             <div class="col-auto">
-                                <span class="avatar"></span>
+                                <span class="avatar">
+                                    <a class="text-muted" href="{{ path('app_admin_system_auditlog_detail', {id: auditlog.id}) }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-search" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
+                                            <path d="M21 21l-6 -6" />
+                                        </svg>
+                                    </a>
+                                </span>
                             </div>
                             <div class="col">
-                                <div class="text-truncate">
-                                    {% if auditlog.user is null %}
-                                        <strong>{{ auditlog.entityType }} ({{ auditlog.entityId }})</strong> was <strong>{{ auditlog.action }}</strong>.
-                                    {% else %}{{ auditlog.user }}
-                                        <strong>{{ auditlog.entityType }} ({{ auditlog.entityId }})</strong> was <strong>{{ auditlog.action }}</strong> by {{ auditlog.user }}.
+                                {% if auditlog.action == 'insert' %}
+                                    <span class="badge bg-green text-white">{{ 'label.action_insert'|trans }}</span>
+                                {% elseif auditlog.action == 'update' %}
+                                    <span class="badge bg-cyan text-white">{{ 'label.action_update'|trans }}</span>
+                                {% elseif auditlog.action == 'remove' %}
+                                    <span class="badge bg-red text-white">{{ 'label.action_remove'|trans }}</span>
+                                {% else %}
+                                    <span class="badge bg-secondary text-white">{{ auditlog.action }}</span>
+                                {% endif %}
+
+                                {% if auditlog.action != 'remove' %}
+                                    {% if auditlog.entityType == 'User' %}
+                                        <a href="{{ path('app_admin_user_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'DispatchArea' %}
+                                        <a href="{{ path('app_admin_area_dispatch_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'State' %}
+                                        <a href="{{ path('app_admin_area_state_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'SupplyArea' %}
+                                        <a href="{{ path('app_admin_area_supply_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% elseif auditlog.entityType == 'Hospital' %}
+                                        <a href="{{ path('app_admin_hospital_show', {id: auditlog.entityId}) }}">{{ auditlog.entityType }} ({{ auditlog.entityId }})</a>
+                                    {% else %}
+                                        {{ auditlog.entityType }} ({{ auditlog.entityId }})
+                                    {% endif %}
+                                {% else %}
+                                    <del class="text-muted">{{ auditlog.entityType }} ({{ auditlog.entityId }})</del>
+                                {% endif %}
+                                <div class="list-inline list-inline-dots text-muted mt-1">
+                                    <div class="list-inline-item">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clock" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+                                            <path d="M12 7v5l3 3" />
+                                        </svg>
+                                        {{ auditlog.createdAt|date('d.m.Y H:i') }}
+                                    </div>
+                                    {% if auditlog.user is not null %}
+                                        <div class="list-inline-item">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-user-square" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                                <path d="M9 10a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
+                                                <path d="M6 21v-1a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v1" />
+                                                <path d="M3 5a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-14z" />
+                                            </svg>
+                                            <a href="{{ path('app_admin_user_show', {id: auditlog.user.id}) }}">{{ auditlog.user }}</a>
+                                        </div>
                                     {% endif %}
                                 </div>
-                                <div class="text-muted">{{ auditlog.createdAt|date('d.m.Y H:i') }}</div>
                             </div>
                         </div>
                     </div>

--- a/templates/data/hospital/show.html.twig
+++ b/templates/data/hospital/show.html.twig
@@ -32,12 +32,10 @@
                     <h1 class="fw-bold">{{ hospital.name }}</h1>
                     <div class="list-inline list-inline-dots text-muted">
                         <div class="list-inline-item">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/map -->
                             <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-inline" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M3 7l6 -3l6 3l6 -3l0 13l-6 3l-6 -3l-6 3l0 -13"></path><path d="M9 4l0 13"></path><path d="M15 7l0 13"></path></svg>
                             {{ hospital.dispatchArea }}, {{ hospital.state }}
                         </div>
                         <div class="list-inline-item">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/cake -->
                             <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-user-square" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                                 <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                 <path d="M9 10a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -918,6 +918,22 @@
         <source>label.address_country</source>
         <target>Country</target>
       </trans-unit>
+      <trans-unit id="31bttpo" resname="label.action">
+        <source>label.action</source>
+        <target>Action</target>
+      </trans-unit>
+      <trans-unit id="ta0nsje" resname="label.action_insert">
+        <source>label.action_insert</source>
+        <target>Insert</target>
+      </trans-unit>
+      <trans-unit id="jVZSJ3h" resname="label.action_update">
+        <source>label.action_update</source>
+        <target>Update</target>
+      </trans-unit>
+      <trans-unit id="Tclr32r" resname="label.action_remove">
+        <source>label.action_remove</source>
+        <target>Remove</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Question              | Answer     |
| --------------------- |------------|
| Bug fix?              | no   |
| New feature?          | no   |
| Refactoring?          | yes   |
| Build related change? | no   |
| CI related change?    | no   |
| Deprecations?         | no   |
| Tickets               | Closes #55  |
| License               | MIT        |

This PR makes the AuditLog much more useable by moving the previous display in the form of some kind of list into a real DataTable with some fancy colors for the actions and links to the currently existing entities. 