### PR TITLE
feat: Toogle password

### DIFF
--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -1,5 +1,14 @@
 {
     "controllers": {
+        "@symfony/ux-toggle-password": {
+            "toggle-password": {
+                "enabled": true,
+                "fetch": "eager",
+                "autoimport": {
+                    "@symfony/ux-toggle-password/dist/style.min.css": true
+                }
+            }
+        },
         "@symfony/ux-turbo": {
             "turbo-core": {
                 "enabled": true,

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "symfony/string": "7.0.*",
         "symfony/translation": "7.0.*",
         "symfony/twig-bundle": "7.0.*",
+        "symfony/ux-toggle-password": "^2.13",
         "symfony/ux-turbo": "^2.13",
         "symfony/ux-twig-component": "^2.13",
         "symfony/validator": "7.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03a286bdaa14c959505beced472f187a",
+    "content-hash": "a482add6e2599611d297fbb7bd3236d4",
     "packages": [
         {
             "name": "composer/semver",
@@ -6972,6 +6972,86 @@
                 }
             ],
             "time": "2023-11-26T15:16:53+00:00"
+        },
+        {
+            "name": "symfony/ux-toggle-password",
+            "version": "v2.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-toggle-password.git",
+                "reference": "133a5ddd204fbfe648b2bcea4e9db93499aa36ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-toggle-password/zipball/133a5ddd204fbfe648b2bcea4e9db93499aa36ce",
+                "reference": "133a5ddd204fbfe648b2bcea4e9db93499aa36ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/form": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/options-resolver": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0"
+            },
+            "require-dev": {
+                "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+                "symfony/twig-bundle": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0",
+                "twig/twig": "^2.14.7|^3.0.4"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/ux",
+                    "url": "https://github.com/symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\TogglePassword\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Félix Eymonot",
+                    "email": "felix.eymonot@alximy.io"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Toggle visibility of password inputs for Symfony Forms",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-toggle-password/tree/v2.13.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-11T01:20:31+00:00"
         },
         {
             "name": "symfony/ux-turbo",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,4 +18,5 @@ return [
     SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
     Symfony\UX\Turbo\TurboBundle::class => ['all' => true],
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
+    Symfony\UX\TogglePassword\TogglePasswordBundle::class => ['all' => true],
 ];

--- a/importmap.php
+++ b/importmap.php
@@ -39,7 +39,7 @@ return [
         'type' => 'css',
     ],
     '@hotwired/turbo' => [
-        'version' => '8.0.0-beta.2',
+        'version' => '7.3.0',
     ],
     'debounce' => [
         'version' => '2.0.0',

--- a/src/Form/Security/ChangePasswordFormType.php
+++ b/src/Form/Security/ChangePasswordFormType.php
@@ -21,6 +21,7 @@ class ChangePasswordFormType extends AbstractType
                     'attr' => [
                         'autocomplete' => 'new-password',
                     ],
+                    'toggle' => true,
                 ],
                 'first_options' => [
                     'constraints' => [

--- a/src/Form/Security/LoginType.php
+++ b/src/Form/Security/LoginType.php
@@ -15,7 +15,9 @@ class LoginType extends AbstractType
     {
         $builder
             ->add('username', TextType::class)
-            ->add('password', PasswordType::class)
+            ->add('password', PasswordType::class, [
+                'toggle' => true,
+            ])
         ;
     }
 

--- a/src/Form/Security/RegistrationType.php
+++ b/src/Form/Security/RegistrationType.php
@@ -36,7 +36,12 @@ class RegistrationType extends AbstractType
                 'mapped' => false,
                 'attr' => ['autocomplete' => 'new-password'],
                 'invalid_message' => 'The password fields must match.',
-                'options' => ['attr' => ['class' => 'password-field']],
+                'options' => [
+                    'attr' => [
+                        'class' => 'password-field',
+                    ],
+                    'toggle' => true,
+                ],
                 'required' => true,
                 'first_options' => ['label' => 'Password'],
                 'second_options' => ['label' => 'Repeat Password'],

--- a/src/Form/Security/ResetPasswordRequestFormType.php
+++ b/src/Form/Security/ResetPasswordRequestFormType.php
@@ -14,7 +14,9 @@ class ResetPasswordRequestFormType extends AbstractType
     {
         $builder
             ->add('email', EmailType::class, [
-                'attr' => ['autocomplete' => 'email'],
+                'attr' => [
+                    'autocomplete' => 'email',
+                ],
                 'constraints' => [
                     new NotBlank([
                         'message' => 'Please enter your email',

--- a/src/Form/User/CreateUserType.php
+++ b/src/Form/User/CreateUserType.php
@@ -18,7 +18,9 @@ class CreateUserType extends AbstractType
     {
         $builder
             ->add('username', TextType::class)
-            ->add('password', PasswordType::class)
+            ->add('password', PasswordType::class, [
+                'toggle' => true,
+            ])
             ->add('email', EmailType::class)
             ->add('roles', ChoiceType::class, [
                 'multiple' => true,

--- a/src/Form/User/EditUserType.php
+++ b/src/Form/User/EditUserType.php
@@ -22,6 +22,7 @@ class EditUserType extends AbstractType
             ->add('username', TextType::class)
             ->add('password', PasswordType::class, [
                 'required' => false,
+                'toggle' => true,
             ])
             ->add('email', EmailType::class)
             ->add('roles', ChoiceType::class, [

--- a/src/Form/User/UpdateUserPasswordType.php
+++ b/src/Form/User/UpdateUserPasswordType.php
@@ -25,9 +25,14 @@ class UpdateUserPasswordType extends AbstractType
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'label' => 'New Password',
-                'attr' => ['autocomplete' => 'new-password'],
+                'attr' => [
+                    'autocomplete' => 'new-password',
+                ],
                 'invalid_message' => 'The password fields must match.',
-                'options' => ['attr' => ['class' => 'password-field']],
+                'options' => [
+                    'attr' => ['class' => 'password-field'],
+                    'toggle' => true,
+                ],
                 'required' => true,
                 'first_options' => ['label' => 'New Password'],
                 'second_options' => ['label' => 'Repeat new Password'],

--- a/symfony.lock
+++ b/symfony.lock
@@ -284,6 +284,9 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/ux-toggle-password": {
+        "version": "v2.13.2"
+    },
     "symfony/ux-turbo": {
         "version": "v2.13.2"
     },


### PR DESCRIPTION
| Question              | Answer     |
| --------------------- |------------|
| Bug fix?              |  no   |
| New feature?          | yes   |
| Refactoring?          | no   |
| Build related change? | no   |
| CI related change?    | no   |
| Deprecations?         |  no   |
| Tickets               | Closes  #57  |
| License               | MIT        |

This pull request addresses the need for a toogle that allows users to see the plaintext of PasswordType fields.